### PR TITLE
feat: add rich completion summary with report path

### DIFF
--- a/claudeloop
+++ b/claudeloop
@@ -1153,14 +1153,28 @@ main() {
   [ $exit_code -eq 0 ] && clear_state
 
   # Auto-archive on successful completion
+  _LAST_ARCHIVE_DIR=""
   if [ $exit_code -eq 0 ] && [ "${_CLAUDELOOP_NO_AUTO_ARCHIVE:-0}" != "1" ] \
      && [ "${_ARCHIVE_DECLINED:-}" != "true" ]; then
-    archive_current_run --internal
+    archive_current_run --internal || print_warning "Auto-archive failed (non-fatal)"
   fi
 
+  # Clear LIVE_LOG after archive (file was moved to archive dir)
+  [ -n "${_LAST_ARCHIVE_DIR:-}" ] && LIVE_LOG=""
+
   echo ""
-  print_header "$PLAN_FILE"
-  print_all_phases
+  if [ $exit_code -eq 0 ]; then
+    _replay_path=""
+    if [ -n "${_LAST_ARCHIVE_DIR:-}" ] && [ -f "$_LAST_ARCHIVE_DIR/replay.html" ]; then
+      _replay_path="$_LAST_ARCHIVE_DIR/replay.html"
+    elif [ -f ".claudeloop/replay.html" ]; then
+      _replay_path=".claudeloop/replay.html"
+    fi
+    print_completion_summary "$PLAN_FILE" "$_replay_path"
+  else
+    print_header "$PLAN_FILE"
+    print_all_phases
+  fi
 
   exit $exit_code
 }

--- a/lib/archive.sh
+++ b/lib/archive.sh
@@ -118,7 +118,10 @@ archive_current_run() {
   # 4. Generate metadata
   generate_archive_metadata "$_archive_dir"
 
-  # 5. Announce
+  # 5. Export archive dir for caller
+  _LAST_ARCHIVE_DIR="$_archive_dir"
+
+  # 6. Announce
   print_success "Run archived to ${_archive_dir}"
 }
 

--- a/lib/ui.sh
+++ b/lib/ui.sh
@@ -139,6 +139,35 @@ print_all_phases() {
   echo ""
 }
 
+# Print rich completion summary after successful run
+# Args: $1 = plan_file, $2 = replay_path (empty if unavailable)
+print_completion_summary() {
+  local plan_file="$1"
+  local replay_path="$2"
+  local completed=0
+  local status
+
+  for _phase in $PHASE_NUMBERS; do
+    status=$(get_phase_status "$_phase")
+    [ "${status:-pending}" = "completed" ] && completed=$((completed + 1))
+  done
+
+  echo "═══════════════════════════════════════════════════════════"
+  echo "Run Summary — $completed/$PHASE_COUNT phases completed"
+  echo "═══════════════════════════════════════════════════════════"
+  printf 'Plan:   %s\n' "$plan_file"
+  if [ -n "$replay_path" ]; then
+    printf 'Report: %s\n' "$replay_path"
+  fi
+  echo ""
+  for _phase in $PHASE_NUMBERS; do
+    printf '  '
+    print_phase_status "$_phase"
+  done
+  echo ""
+  echo "═══════════════════════════════════════════════════════════"
+}
+
 # Print phase execution header
 print_phase_exec_header() {
   local phase_num="$1"

--- a/tests/test_archive.sh
+++ b/tests/test_archive.sh
@@ -556,6 +556,27 @@ EOF
 
 # --- archive_current_run mkdir failure ---
 
+@test "archive_current_run: sets _LAST_ARCHIVE_DIR on success" {
+  _create_run_state
+  _LAST_ARCHIVE_DIR=""
+
+  archive_current_run --internal
+
+  [ -n "$_LAST_ARCHIVE_DIR" ]
+  [ -d "$_LAST_ARCHIVE_DIR" ]
+  # Should point to the archive directory
+  echo "$_LAST_ARCHIVE_DIR" | grep -q ".claudeloop/archive/"
+}
+
+@test "archive_current_run: _LAST_ARCHIVE_DIR stays empty on nothing to archive" {
+  mkdir -p .claudeloop
+  _LAST_ARCHIVE_DIR=""
+
+  archive_current_run --internal
+
+  [ -z "$_LAST_ARCHIVE_DIR" ]
+}
+
 @test "archive_current_run: returns 1 when archive directory cannot be created" {
   cd "$BATS_TEST_TMPDIR"
   mkdir -p .claudeloop

--- a/tests/test_ui.sh
+++ b/tests/test_ui.sh
@@ -280,6 +280,97 @@ setup() {
   rm -f "$tmplog"
 }
 
+# --- print_completion_summary() ---
+
+@test "print_completion_summary: shows Run Summary header" {
+  PHASE_STATUS_1="completed"
+  PHASE_STATUS_2="completed"
+  PHASE_STATUS_3="completed"
+  run print_completion_summary "PLAN.md" ""
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Run Summary"* ]]
+  [[ "$output" == *"3/3 phases completed"* ]]
+}
+
+@test "print_completion_summary: shows plan file" {
+  run print_completion_summary "my-plan.md" ""
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Plan:   my-plan.md"* ]]
+}
+
+@test "print_completion_summary: shows report path when provided" {
+  run print_completion_summary "PLAN.md" ".claudeloop/archive/20260320-143022/replay.html"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Report: .claudeloop/archive/20260320-143022/replay.html"* ]]
+}
+
+@test "print_completion_summary: omits report line when path is empty" {
+  run print_completion_summary "PLAN.md" ""
+  [ "$status" -eq 0 ]
+  [[ "$output" != *"Report:"* ]]
+}
+
+@test "print_completion_summary: counts completed phases correctly" {
+  PHASE_STATUS_1="completed"
+  PHASE_STATUS_2="failed"
+  PHASE_STATUS_3="pending"
+  run print_completion_summary "PLAN.md" ""
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"1/3 phases completed"* ]]
+}
+
+@test "print_completion_summary: shows all phase statuses with icons" {
+  PHASE_STATUS_1="completed"
+  PHASE_STATUS_2="completed"
+  PHASE_STATUS_3="completed"
+  run print_completion_summary "PLAN.md" ""
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"✅"*"Setup"* ]]
+  [[ "$output" == *"✅"*"Implementation"* ]]
+  [[ "$output" == *"✅"*"Testing"* ]]
+}
+
+@test "print_completion_summary: indents phase lines with 2 spaces" {
+  PHASE_STATUS_1="completed"
+  PHASE_STATUS_2="completed"
+  PHASE_STATUS_3="completed"
+  run print_completion_summary "PLAN.md" ""
+  [ "$status" -eq 0 ]
+  # Check that phase lines start with 2-space indent
+  echo "$output" | grep -q "^  .*Phase 1"
+}
+
+@test "print_completion_summary: shows separator lines" {
+  run print_completion_summary "PLAN.md" ""
+  [ "$status" -eq 0 ]
+  # Should have 3 separator lines (top, after header, bottom)
+  local count
+  count=$(echo "$output" | grep -c "═══════════════════════════════════════════════════════════")
+  [ "$count" -eq 3 ]
+}
+
+@test "print_completion_summary: handles zero phases" {
+  PHASE_COUNT=0
+  PHASE_NUMBERS=""
+  run print_completion_summary "PLAN.md" ""
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"0/0 phases completed"* ]]
+}
+
+@test "print_completion_summary: handles decimal phase numbers" {
+  PHASE_COUNT=4
+  PHASE_NUMBERS="1 2 2.5 3"
+  PHASE_TITLE_2_5="Bugfix"
+  PHASE_STATUS_2_5="completed"
+  PHASE_STATUS_1="completed"
+  PHASE_STATUS_2="completed"
+  PHASE_STATUS_3="completed"
+  run print_completion_summary "PLAN.md" ""
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"4/4 phases completed"* ]]
+  [[ "$output" == *"Bugfix"* ]]
+}
+
 @test "log_live writes blank line for empty string" {
   local tmplog
   tmplog=$(mktemp)


### PR DESCRIPTION
## Summary
- Adds `print_completion_summary` to `lib/ui.sh` showing a Run Summary box with plan file, report path, and phase status list on successful completion
- Exports `_LAST_ARCHIVE_DIR` from `archive_current_run()` so the caller can locate the archived replay.html
- Updates `claudeloop` main to use the new summary on success, preserving existing `print_header`+`print_all_phases` on failure

Closes #15

## Test plan
- [x] 10 new tests for `print_completion_summary` (separator lines, plan/report display, phase icons, decimal phases, zero phases)
- [x] 2 new tests for `_LAST_ARCHIVE_DIR` (set on success, empty when nothing to archive)
- [x] Full test suite passes (27/27 suites)
- [x] Smoke test passes (8/8)
- [x] GUI verification: completion box renders correctly in Terminal.app

🤖 Generated with [Claude Code](https://claude.com/claude-code)