### PR TITLE
feat: bidirectional stdio protocol + API error handling

### DIFF
--- a/claudeloop
+++ b/claudeloop
@@ -39,6 +39,7 @@ _CL_REFACTOR_MAX_RETRIES="${REFACTOR_MAX_RETRIES:-}"
 . "$SCRIPT_DIR/lib/prompt.sh"
 . "$SCRIPT_DIR/lib/stream_processor.sh"
 . "$SCRIPT_DIR/lib/ai_parser.sh"
+. "$SCRIPT_DIR/lib/permission_handler.sh"
 . "$SCRIPT_DIR/lib/verify.sh"
 . "$SCRIPT_DIR/lib/refactor.sh"
 . "$SCRIPT_DIR/lib/execution.sh"
@@ -233,6 +234,8 @@ handle_interrupt() {
     CURRENT_PIPELINE_PID=""
     CURRENT_PIPELINE_PGID=""
   fi
+  # Close permission FIFO write end (FD 7) if still open
+  exec 7>&- 2>/dev/null || true
   INTERRUPTED=true
   echo ""
   print_warning "Interrupt received (Ctrl+C)"
@@ -633,6 +636,8 @@ _add_platform_gitignore() {
 main_loop() {
   local continue_execution=true
   local _net_retries=0
+  local _overload_retries=0
+  local _server_retries=0
 
   while $continue_execution; do
     # Check for interruption
@@ -679,15 +684,62 @@ main_loop() {
     if execute_phase "$next_phase"; then
       log_verbose "main_loop: phase $next_phase succeeded, continuing"
       _net_retries=0
+      _overload_retries=0
+      _server_retries=0
       # Success - continue to next phase
       continue
     else
-      local _log_file
+      local _log_file _raw_file
       _log_file=".claudeloop/logs/phase-${next_phase}.log"
-      if is_quota_error "$_log_file"; then
-        # Quota error: restore attempt counter (same pattern as handle_interrupt)
+      _raw_file=".claudeloop/logs/phase-${next_phase}.raw.json"
+      if is_overload_error "$_log_file" "$_raw_file"; then
+        _overload_retries=$((_overload_retries + 1))
         reset_phase_for_retry "$next_phase"
-        log_verbose "main_loop: quota error on phase $next_phase, attempts restored"
+        # Exponential backoff: 5, 10, 20, 40, 80, 120, 120... (cap 120s)
+        local _ol_delay=0
+        if [ "${BASE_DELAY:-5}" -gt 0 ]; then
+          _ol_delay=$((5 * (1 << (_overload_retries - 1))))
+          [ "$_ol_delay" -gt 120 ] && _ol_delay=120
+        fi
+        log_verbose "main_loop: overload error on phase $next_phase (retry $_overload_retries), waiting ${_ol_delay}s"
+        write_progress "$PROGRESS_FILE" "$PLAN_FILE"
+        print_overload_wait "$next_phase" "$_overload_retries" "$_ol_delay"
+        sleep "$_ol_delay"
+        if [ "$_overload_retries" -ge 20 ]; then
+          if [ -t 0 ] && [ "$YES_MODE" != "true" ]; then
+            printf 'API overloaded for an extended period. Press Enter to keep retrying or Ctrl+C to exit: '
+            read -r _dummy 2>/dev/null || return 1
+            _overload_retries=0
+          fi
+        fi
+        continue
+      fi
+      if is_server_error "$_log_file" "$_raw_file" || is_timeout_error "$_log_file"; then
+        _server_retries=$((_server_retries + 1))
+        reset_phase_for_retry "$next_phase"
+        # Exponential backoff: 5, 10, 20, 40, 80, 160, 300, 300... (cap 300s)
+        local _sv_delay=0
+        if [ "${BASE_DELAY:-5}" -gt 0 ]; then
+          _sv_delay=$((5 * (1 << (_server_retries - 1))))
+          [ "$_sv_delay" -gt 300 ] && _sv_delay=300
+        fi
+        log_verbose "main_loop: server/timeout error on phase $next_phase (retry $_server_retries), waiting ${_sv_delay}s"
+        write_progress "$PROGRESS_FILE" "$PLAN_FILE"
+        print_server_error_wait "$next_phase" "$_server_retries" "$_sv_delay"
+        sleep "$_sv_delay"
+        if [ "$_server_retries" -ge 20 ]; then
+          if [ -t 0 ] && [ "$YES_MODE" != "true" ]; then
+            printf 'API server errors for an extended period. Press Enter to keep retrying or Ctrl+C to exit: '
+            read -r _dummy 2>/dev/null || return 1
+            _server_retries=0
+          fi
+        fi
+        continue
+      fi
+      if is_rate_limit_error "$_log_file"; then
+        # Rate-limit/quota error: restore attempt counter (same pattern as handle_interrupt)
+        reset_phase_for_retry "$next_phase"
+        log_verbose "main_loop: rate-limit error on phase $next_phase, attempts restored"
         write_progress "$PROGRESS_FILE" "$PLAN_FILE"
         print_quota_wait "$next_phase" "$QUOTA_RETRY_INTERVAL"
         sleep "$QUOTA_RETRY_INTERVAL"

--- a/lib/execution.sh
+++ b/lib/execution.sh
@@ -57,6 +57,21 @@ run_claude_pipeline() {
   local _saved_stty=""
   _saved_stty=$(stty -g 2>/dev/null < /dev/tty) || true
 
+  # Create named pipe for bidirectional stdio protocol
+  local _claude_fifo
+  _claude_fifo=$(mktemp -u).fifo
+  mkfifo "$_claude_fifo"
+
+  # Build prompt as stream-json message
+  local _prompt_json
+  _prompt_json=$(_build_stream_message "$_rcp_prompt")
+
+  # Open FIFO in read-write mode — avoids blocking that happens with
+  # write-only open when no reader exists yet. All pipeline stages inherit FD 7.
+  # permission_filter writes control_responses to FD 7, which claude reads via stdin.
+  exec 7<>"$_claude_fifo"
+  printf '%s\n' "$_prompt_json" >&7
+
   # Use job control (set -m) so the background pipeline gets its own process group.
   # This lets the timer (and handle_interrupt) kill the entire pipeline by PGID,
   # not just the last process. Without set -m, kill -TERM $! only kills the last
@@ -65,19 +80,13 @@ run_claude_pipeline() {
   {
     _rc=0
     unset CLAUDECODE   # strip Claude Code marker — nested claude invocations require it unset
-    if [ "$SKIP_PERMISSIONS" = "true" ]; then
-      # shellcheck disable=SC2086
-      printf '%s\n' "$_rcp_prompt" | claude --print --dangerously-skip-permissions \
-        --output-format=stream-json --verbose --include-partial-messages \
-        $_claude_debug_flag 2>&1 || _rc=$?
-    else
-      # shellcheck disable=SC2086
-      printf '%s\n' "$_rcp_prompt" | claude --print \
-        --output-format=stream-json --verbose --include-partial-messages \
-        $_claude_debug_flag 2>&1 || _rc=$?
-    fi
+    # shellcheck disable=SC2086
+    claude --input-format stream-json --output-format stream-json \
+      --permission-prompt-tool stdio --verbose --include-partial-messages \
+      $_claude_debug_flag \
+      < "$_claude_fifo" 7>&- 2>&1 || _rc=$?
     printf '%s\n' "$_rc" > "$_exit_tmp"
-  } | inject_heartbeats | { process_stream_json "$_rcp_log" "$_rcp_raw" "$HOOKS_ENABLED" "${LIVE_LOG:-}" "${SIMPLE_MODE:-false}" "${IDLE_TIMEOUT:-0}"; : > "$_sentinel"; } &
+  } | permission_filter | inject_heartbeats | { process_stream_json "$_rcp_log" "$_rcp_raw" "$HOOKS_ENABLED" "${LIVE_LOG:-}" "${SIMPLE_MODE:-false}" "${IDLE_TIMEOUT:-0}"; : > "$_sentinel"; } &
   CURRENT_PIPELINE_PID=$!
   # With set -m the pipeline's PGID = PID of the first process (jobs -p shows it)
   CURRENT_PIPELINE_PGID=$(jobs -p 2>/dev/null | tr -d '[:space:]')
@@ -129,7 +138,9 @@ run_claude_pipeline() {
     kill -TERM -- "-$CURRENT_PIPELINE_PGID" 2>/dev/null || true
   fi
   wait "$CURRENT_PIPELINE_PID" 2>/dev/null || true
+  exec 7>&- 2>/dev/null || true
   rm -f "$_sentinel"
+  rm -f "$_claude_fifo"
   # Clear spinner remnants and show cursor
   printf '\r%-24s\r' '' >/dev/stderr
   CURRENT_PIPELINE_PID=""

--- a/lib/permission_handler.sh
+++ b/lib/permission_handler.sh
@@ -1,0 +1,140 @@
+#!/bin/sh
+
+# Permission Handler Library
+# Handles bidirectional stdio protocol for Claude Code permission requests.
+# Provides permission_filter() pipeline stage and response builders.
+
+# Extract a simple string field value from JSON using awk
+# Args: $1 - JSON string, $2 - field name
+# Returns: field value (stdout), empty string if not found
+_extract_field() {
+  printf '%s' "$1" | awk -v key="$2" '{
+    tag = "\"" key "\":\""
+    i = index($0, tag)
+    if (i == 0) { print ""; exit }
+    i += length(tag)
+    val = ""
+    for (j = i; j <= length($0); j++) {
+      c = substr($0, j, 1)
+      if (c == "\\") { val = val substr($0, j, 2); j++; continue }
+      if (c == "\"") break
+      val = val c
+    }
+    print val
+  }'
+}
+
+# Build a stream-json user message from plain text prompt
+# Args: $1 - prompt content (plain text)
+# Returns: JSON message (stdout)
+_build_stream_message() {
+  local _content="$1"
+  # JSON-encode the content (escape \, ", newlines, tabs)
+  local _encoded
+  _encoded=$(printf '%s' "$_content" | awk '{
+    gsub(/\\/, "\\\\")
+    gsub(/"/, "\\\"")
+    gsub(/\t/, "\\t")
+    if (NR > 1) printf "\\n"
+    printf "%s", $0
+  }')
+  printf '{"type":"user","message":{"role":"user","content":"%s"},"parent_tool_use_id":null,"session_id":"default"}' "$_encoded"
+}
+
+# Build an allow response for a control_request (requires node.js)
+# Uses node for reliable JSON parsing — ~50ms per call, acceptable for infrequent permissions
+# Args: $1 - control_request JSON line
+# Returns: control_response JSON (stdout)
+_build_allow_response() {
+  printf '%s' "$1" | node -e "
+    const j=JSON.parse(require('fs').readFileSync('/dev/stdin','utf8'));
+    console.log(JSON.stringify({
+      type:'control_response',
+      response:{subtype:'success',request_id:j.request_id,
+        response:{behavior:'allow',updatedInput:j.request.input}}
+    }));
+  "
+}
+
+# Build a deny response for a control_request (awk-based, no node needed)
+# Args: $1 - control_request JSON line
+# Returns: control_response JSON (stdout)
+_build_deny_response() {
+  local _req_id
+  _req_id=$(_extract_field "$1" "request_id")
+  printf '{"type":"control_response","response":{"subtype":"success","request_id":"%s","response":{"behavior":"deny","message":"User denied"}}}\n' "$_req_id"
+}
+
+# Handle a single control_request event
+# Writes response to stdout (caller redirects to FD 3 → claude's stdin)
+# Args: $1 - control_request JSON line
+_handle_control_request() {
+  local _cr_line="$1"
+
+  if [ "$SKIP_PERMISSIONS" = "true" ]; then
+    # Auto-approve mode
+    log_verbose "permission_filter: auto-approving permission request"
+    _build_allow_response "$_cr_line"
+    return
+  fi
+
+  # Interactive mode: check for TTY
+  if [ -t 0 ] 2>/dev/null || [ -e /dev/tty ]; then
+    local _tool_name _reason
+    _tool_name=$(_extract_field "$_cr_line" "tool_name")
+    _reason=$(_extract_field "$_cr_line" "message")
+    [ -z "$_reason" ] && _reason="Permission requested"
+
+    # Display on /dev/tty (not stdout, which is the pipeline)
+    {
+      printf '[%s] Permission requested: %s\n' "$(date '+%H:%M:%S')" "$_tool_name"
+      printf '  Reason: %s\n' "$_reason"
+      printf '  Allow? (y/n): '
+    } > /dev/tty 2>/dev/null || true
+
+    local _answer=""
+    read -r _answer < /dev/tty 2>/dev/null || _answer="n"
+    case "$_answer" in
+      [Yy]|[Yy][Ee][Ss])
+        _build_allow_response "$_cr_line"
+        ;;
+      *)
+        _build_deny_response "$_cr_line"
+        ;;
+    esac
+    return
+  fi
+
+  # Non-interactive, no skip: auto-deny
+  log_verbose "permission_filter: auto-denying (non-interactive, SKIP_PERMISSIONS=false)"
+  _build_deny_response "$_cr_line"
+}
+
+# FD used for writing control_responses back to claude's stdin via FIFO.
+# Default FD 7 (avoids conflict with bats FD 3 and shell FDs 0-2).
+# Callers open this FD before starting the pipeline:
+#   exec 7<>"$_fifo"; ... | permission_filter | ...
+_PERMISSION_FD=${_PERMISSION_FD:-7}
+
+# Pipeline filter: reads claude's stdout, intercepts control_requests,
+# passes everything else downstream. Writes responses to the permission FD
+# (default FD 7 = claude's stdin via FIFO).
+# Must be called with FD $_PERMISSION_FD open to the FIFO.
+permission_filter() {
+  while IFS= read -r _pf_line; do
+    case "$_pf_line" in
+      *'"type":"control_request"'*)
+        _handle_control_request "$_pf_line" >&"$_PERMISSION_FD"
+        ;;
+      *'"type":"keep_alive"'*)
+        : # Ignore keep-alive events
+        ;;
+      *'"type":"control_cancel_request"'*)
+        : # Ignore cancel requests (we respond immediately, nothing to cancel)
+        ;;
+      *)
+        printf '%s\n' "$_pf_line"  # Pass through to downstream
+        ;;
+    esac
+  done
+}

--- a/lib/retry.sh
+++ b/lib/retry.sh
@@ -17,13 +17,49 @@ calculate_backoff() {
   echo "$BASE_DELAY"
 }
 
-# Check if a phase log contains quota/rate-limit error output
+# Check if a phase log contains a rate-limit/quota error (not overloaded — see is_overload_error)
 # Args: $1 - path to log file
-# Returns: 0 if quota error detected, 1 otherwise
-is_quota_error() {
+# Returns: 0 if rate-limit error detected, 1 otherwise
+is_rate_limit_error() {
   local log_file="$1"
   [ -f "$log_file" ] || return 1
-  grep -qiE "usage limit|quota|rate.?limit|too many requests|rate_limit_error|overloaded" "$log_file"
+  grep -qiE "usage limit|quota|rate.?limit|too many requests|rate_limit_error" "$log_file"
+}
+
+# Backward-compatible alias
+is_quota_error() { is_rate_limit_error "$@"; }
+
+# Check if a phase log contains an overloaded/529 error
+# Args: $1 - log file, $2 - raw JSON log (optional)
+# Returns: 0 if overload error detected, 1 otherwise
+is_overload_error() {
+  local log_file="$1"
+  local raw_file="${2:-}"
+  local _olp="overloaded|overloaded_error|529"
+  [ -f "$log_file" ] && grep -qiE "$_olp" "$log_file" && return 0
+  [ -n "$raw_file" ] && [ -f "$raw_file" ] && grep -qiE "$_olp" "$raw_file" && return 0
+  return 1
+}
+
+# Check if a phase log contains a server error (500/502/503/api_error)
+# Args: $1 - log file, $2 - raw JSON log (optional)
+# Returns: 0 if server error detected, 1 otherwise
+is_server_error() {
+  local log_file="$1"
+  local raw_file="${2:-}"
+  local _sep="api_error|internal_server_error|[Ss]erver error|HTTP 50[023]"
+  [ -f "$log_file" ] && grep -qiE "$_sep" "$log_file" && return 0
+  [ -n "$raw_file" ] && [ -f "$raw_file" ] && grep -qiE "$_sep" "$raw_file" && return 0
+  return 1
+}
+
+# Check if a phase log contains a request timeout error (408)
+# Args: $1 - log file
+# Returns: 0 if timeout error detected, 1 otherwise
+is_timeout_error() {
+  local log_file="$1"
+  [ -f "$log_file" ] || return 1
+  grep -qiE "request_timeout|HTTP 408|request timed out" "$log_file"
 }
 
 # Check if a phase log contains an unanswered permission prompt from Claude
@@ -58,7 +94,7 @@ is_network_error() {
 is_auth_error() {
   local log_file="$1"
   local raw_file _auth_pat
-  _auth_pat="authentication_error|invalid.*credentials|invalid.api.key|not_authorized"
+  _auth_pat="authentication_error|invalid.*credentials|invalid.api.key|not_authorized|permission_error|not_found_error"
   [ -f "$log_file" ] && grep -qiE "$_auth_pat" "$log_file" && return 0
   raw_file="$(dirname "$log_file")/raw-phase-$(basename "$log_file" .log | sed 's/^phase-//').json"
   [ -f "$raw_file" ] && grep -qiE "$_auth_pat" "$raw_file" && return 0
@@ -174,6 +210,8 @@ fail_reason_hint() {
       echo "The previous attempt crashed or was killed before completing. Start fresh and work through the task methodically." ;;
     verification_failed)
       echo "Your previous changes failed verification. See the verification section below for details." ;;
+    permission_denied)
+      echo "Permission was denied for a file operation. Skip the denied file or use a different approach." ;;
     *) ;;
   esac
 }
@@ -214,7 +252,7 @@ escalate_strategy() {
 
   local _escalated="$_base"
   case "$_reason" in
-    trapped_tool_calls|no_write_actions)
+    trapped_tool_calls|no_write_actions|permission_denied)
       if [ "$_consec" -ge 5 ]; then
         _escalated="targeted"
       elif [ "$_consec" -ge 3 ]; then

--- a/lib/ui.sh
+++ b/lib/ui.sh
@@ -247,6 +247,30 @@ print_network_wait() {
   log_live "  Press Ctrl+C to stop and save state."
 }
 
+# Print an overload (529) retry notice with exponential backoff info
+# Args: $1 - phase_num, $2 - retry_count, $3 - delay_seconds
+print_overload_wait() {
+  local phase_num="$1"
+  local retry_count="$2"
+  local delay_secs="$3"
+  printf '%b\n' "[$(date '+%H:%M:%S')] ${COLOR_YELLOW}⏳ Phase $phase_num: API overloaded (529) — retry $retry_count, waiting ${delay_secs}s...${COLOR_RESET}"
+  log_live "⏳ Phase $phase_num: API overloaded (529) — retry $retry_count, waiting ${delay_secs}s..."
+  printf '%b\n' "[$(date '+%H:%M:%S')] ${COLOR_YELLOW}  Press Ctrl+C to stop and save state.${COLOR_RESET}"
+  log_live "  Press Ctrl+C to stop and save state."
+}
+
+# Print a server error retry notice with exponential backoff info
+# Args: $1 - phase_num, $2 - retry_count, $3 - delay_seconds
+print_server_error_wait() {
+  local phase_num="$1"
+  local retry_count="$2"
+  local delay_secs="$3"
+  printf '%b\n' "[$(date '+%H:%M:%S')] ${COLOR_YELLOW}⚠ Phase $phase_num: API server error — retry $retry_count, waiting ${delay_secs}s...${COLOR_RESET}"
+  log_live "⚠ Phase $phase_num: API server error — retry $retry_count, waiting ${delay_secs}s..."
+  printf '%b\n' "[$(date '+%H:%M:%S')] ${COLOR_YELLOW}  Press Ctrl+C to stop and save state.${COLOR_RESET}"
+  log_live "  Press Ctrl+C to stop and save state."
+}
+
 # Print a message only when VERBOSE_MODE is true
 log_verbose() {
   [ "$VERBOSE_MODE" = "true" ] && printf '[verbose] %s\n' "$*" >&2 || true

--- a/lib/verify.sh
+++ b/lib/verify.sh
@@ -71,12 +71,17 @@ WARNING: Omitting the verdict causes automatic failure. Do not end without it."
   : > "$verify_formatted_log"
 
   # Run claude piped through process_stream_json (same pattern as execute_phase)
-  local _exit_tmp _skip_flag
+  local _exit_tmp
   _exit_tmp=$(mktemp)
-  _skip_flag=""
-  if [ "$SKIP_PERMISSIONS" = "true" ]; then
-    _skip_flag="--dangerously-skip-permissions"
-  fi
+
+  # Create named pipe for bidirectional stdio protocol
+  local _verify_fifo
+  _verify_fifo=$(mktemp -u).fifo
+  mkfifo "$_verify_fifo"
+
+  # Build prompt as stream-json message
+  local _prompt_json
+  _prompt_json=$(_build_stream_message "$prompt")
 
   # Sentinel file: created when stream processor (AWK) exits.
   local _sentinel
@@ -87,15 +92,20 @@ WARNING: Omitting the verdict causes automatic failure. Do not end without it."
   local _saved_stty=""
   _saved_stty=$(stty -g 2>/dev/null < /dev/tty) || true
 
+  # Open FIFO in read-write mode — avoids blocking that happens with
+  # write-only open when no reader exists yet. All pipeline stages inherit FD 7.
+  # permission_filter writes control_responses to FD 7, which claude reads via stdin.
+  exec 7<>"$_verify_fifo"
+  printf '%s\n' "$_prompt_json" >&7
+
   set -m
   {
     _rc=0
-    # shellcheck disable=SC2086
-    printf '%s\n' "$prompt" | claude --print --output-format=stream-json --verbose \
-      --include-partial-messages \
-      $_skip_flag 2>&1 || _rc=$?
+    claude --input-format stream-json --output-format stream-json \
+      --permission-prompt-tool stdio --verbose --include-partial-messages \
+      < "$_verify_fifo" 7>&- 2>&1 || _rc=$?
     printf '%s\n' "$_rc" > "$_exit_tmp"
-  } | inject_heartbeats | { process_stream_json "$verify_formatted_log" "$verify_log" \
+  } | permission_filter | inject_heartbeats | { process_stream_json "$verify_formatted_log" "$verify_log" \
       "false" "${LIVE_LOG:-}" "${SIMPLE_MODE:-false}" "0"; : > "$_sentinel"; } &
   CURRENT_PIPELINE_PID=$!
   CURRENT_PIPELINE_PGID=$(jobs -p 2>/dev/null | tr -d '[:space:]')
@@ -126,7 +136,9 @@ WARNING: Omitting the verdict causes automatic failure. Do not end without it."
     kill -TERM -- "-$CURRENT_PIPELINE_PGID" 2>/dev/null || true
   fi
   wait "$CURRENT_PIPELINE_PID" 2>/dev/null || true
+  exec 7>&- 2>/dev/null || true
   rm -f "$_sentinel"
+  rm -f "$_verify_fifo"
   # Clear spinner remnants on current line (panel already cleaned by deactivate_panel)
   printf '\r%-12s\r' '' >/dev/stderr
   CURRENT_PIPELINE_PID=""

--- a/tests/fake_claude
+++ b/tests/fake_claude
@@ -23,7 +23,25 @@ count=$((count + 1))
 printf '%s' "$count" > "$FAKE_CLAUDE_DIR/call_count"
 
 mkdir -p "$FAKE_CLAUDE_DIR/prompts" "$FAKE_CLAUDE_DIR/args"
-cat > "$FAKE_CLAUDE_DIR/prompts/prompt_$count"
+
+# Detect stream-json input format (bidirectional stdio protocol)
+_stream_json_input=false
+for _arg in "$@"; do
+  case "$_arg" in
+    --input-format) _stream_json_input=true ;;
+    stream-json) ;; # handled by prior flag
+    --permission-prompt-tool) ;; # accept but ignore
+    stdio) ;; # accept but ignore
+  esac
+done
+
+if [ "$_stream_json_input" = "true" ]; then
+  # Read stream-json message from stdin (one line of JSON, don't wait for EOF)
+  IFS= read -r _raw_input 2>/dev/null || _raw_input=""
+  printf '%s' "$_raw_input" > "$FAKE_CLAUDE_DIR/prompts/prompt_$count"
+else
+  cat > "$FAKE_CLAUDE_DIR/prompts/prompt_$count"
+fi
 printf '%s\n' "$@" > "$FAKE_CLAUDE_DIR/args/args_$count"
 
 # --- Scenario selection ---
@@ -267,6 +285,38 @@ scenario_read_only() {
   printf '{"type":"tool_result","content":"/tmp/test.sh:echo hello","id":"toolu_fake_031"}\n'
   printf '{"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"The code looks correct.\\n"}]}}\n'
   printf '{"type":"result","total_cost_usd":0.02,"duration_ms":5000,"num_turns":3,"usage":{"input_tokens":800,"output_tokens":300},"modelUsage":{"fake-claude-v1":{"input_tokens":800,"output_tokens":300}}}\n'
+}
+
+scenario_overload_error() {
+  default_exit=1
+  printf '{"type":"system","subtype":"init","model":"fake-claude-v1"}\n'
+  printf '{"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"overloaded_error: The API is overloaded, please try again later\\n"}]}}\n'
+  printf '{"type":"result","total_cost_usd":0,"duration_ms":200,"num_turns":0,"usage":{"input_tokens":0,"output_tokens":0},"modelUsage":{"fake-claude-v1":{"input_tokens":0,"output_tokens":0}}}\n'
+}
+
+scenario_server_error() {
+  default_exit=1
+  printf '{"type":"system","subtype":"init","model":"fake-claude-v1"}\n'
+  printf '{"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"api_error: Internal server error\\n"}]}}\n'
+  printf '{"type":"result","total_cost_usd":0,"duration_ms":200,"num_turns":0,"usage":{"input_tokens":0,"output_tokens":0},"modelUsage":{"fake-claude-v1":{"input_tokens":0,"output_tokens":0}}}\n'
+}
+
+scenario_timeout_error() {
+  default_exit=1
+  printf '{"type":"system","subtype":"init","model":"fake-claude-v1"}\n'
+  printf '{"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"request_timeout: The request timed out\\n"}]}}\n'
+  printf '{"type":"result","total_cost_usd":0,"duration_ms":200,"num_turns":0,"usage":{"input_tokens":0,"output_tokens":0},"modelUsage":{"fake-claude-v1":{"input_tokens":0,"output_tokens":0}}}\n'
+}
+
+scenario_permission_request() {
+  # Emits a control_request (permission prompt) then continues with success
+  default_exit=0
+  printf '{"type":"system","subtype":"init","model":"fake-claude-v1"}\n'
+  printf '{"type":"control_request","request_id":"req_perm_001","request":{"type":"can_use_tool","tool_name":"Write","input":{"file_path":".claude/skills/test.md","content":"test"}}}\n'
+  printf '{"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"I will make changes."}]}}\n'
+  printf '{"type":"tool_use","name":"Edit","input":{"file_path":"/tmp/test.sh","new_string":"echo hello"},"id":"toolu_perm_001"}\n'
+  printf '{"type":"tool_result","content":"ok","id":"toolu_perm_001"}\n'
+  printf '{"type":"result","total_cost_usd":0.01,"duration_ms":3000,"num_turns":2,"usage":{"input_tokens":500,"output_tokens":200},"modelUsage":{"fake-claude-v1":{"input_tokens":500,"output_tokens":200}}}\n'
 }
 
 scenario_custom() {

--- a/tests/smoke.sh
+++ b/tests/smoke.sh
@@ -40,6 +40,7 @@ write_stub() {
   mkdir -p "$dir/bin"
   cat > "$dir/bin/claude" << STUBEOF
 #!/bin/sh
+read -r _discard 2>/dev/null || true
 count_file="${dir}/claude_call_count"
 count=\$(cat "\$count_file" 2>/dev/null || echo 0)
 count=\$((count + 1))

--- a/tests/test_integration_basic.sh
+++ b/tests/test_integration_basic.sh
@@ -13,6 +13,7 @@ _write_claude_stub() {
   mkdir -p "$dir/bin"
   cat > "$dir/bin/claude" << EOF
 #!/bin/sh
+read -r _discard 2>/dev/null || true
 count_file="${dir}/claude_call_count"
 count=\$(cat "\$count_file" 2>/dev/null || echo 0)
 count=\$((count + 1))
@@ -475,6 +476,7 @@ EOF
   # Embed TEST_DIR into the stub at write-time so the path is resolved now
   cat > "$TEST_DIR/bin/claude" << EOF
 #!/bin/sh
+read -r _discard 2>/dev/null || true
 if [ -n "\${CLAUDECODE:-}" ]; then exit 99; fi
 count_file="$TEST_DIR/claude_call_count"
 count=\$(cat "\$count_file" 2>/dev/null || echo 0)

--- a/tests/test_integration_retry.sh
+++ b/tests/test_integration_retry.sh
@@ -13,6 +13,7 @@ _write_claude_stub() {
   mkdir -p "$dir/bin"
   cat > "$dir/bin/claude" << EOF
 #!/bin/sh
+read -r _discard 2>/dev/null || true
 count_file="${dir}/claude_call_count"
 count=\$(cat "\$count_file" 2>/dev/null || echo 0)
 count=\$((count + 1))
@@ -178,6 +179,7 @@ _call_count() {
   # Writing in a loop ensures SIGPIPE is delivered when the downstream pipe breaks.
   cat > "$TEST_DIR/bin/claude" << EOF
 #!/bin/sh
+read -r _discard 2>/dev/null || true
 count_file="$TEST_DIR/claude_call_count"
 count=\$(cat "\$count_file" 2>/dev/null || echo 0)
 count=\$((count + 1))
@@ -228,11 +230,12 @@ EOF
   # Stub: captures stdin (the prompt) to a per-call file, first call outputs error+fails
   cat > "$TEST_DIR/bin/claude" << EOF
 #!/bin/sh
+read -r _line 2>/dev/null || true
 count_file="$TEST_DIR/claude_call_count"
 count=\$(cat "\$count_file" 2>/dev/null || echo 0)
 count=\$((count + 1))
 printf '%s\n' "\$count" > "\$count_file"
-cat > "$TEST_DIR/claude_prompt_\${count}.txt"
+printf '%s\n' "\$_line" > "$TEST_DIR/claude_prompt_\${count}.txt"
 if [ "\$count" -eq 1 ]; then
   printf 'UNIQUE_ERROR_MARKER_XYZ123\n'
   exit 1
@@ -336,6 +339,7 @@ PROG
   # should detect stream processor exit and kill the lingering Claude process.
   cat > "$TEST_DIR/bin/claude" << EOF
 #!/bin/sh
+read -r _discard 2>/dev/null || true
 count_file="$TEST_DIR/claude_call_count"
 count=\$(cat "\$count_file" 2>/dev/null || echo 0)
 count=\$((count + 1))

--- a/tests/test_integration_state.sh
+++ b/tests/test_integration_state.sh
@@ -12,6 +12,7 @@ _write_claude_stub() {
   mkdir -p "$dir/bin"
   cat > "$dir/bin/claude" << EOF
 #!/bin/sh
+read -r _discard 2>/dev/null || true
 count_file="${dir}/claude_call_count"
 count=\$(cat "\$count_file" 2>/dev/null || echo 0)
 count=\$((count + 1))

--- a/tests/test_integration_state2.sh
+++ b/tests/test_integration_state2.sh
@@ -13,6 +13,7 @@ _write_claude_stub() {
   mkdir -p "$dir/bin"
   cat > "$dir/bin/claude" << EOF
 #!/bin/sh
+read -r _discard 2>/dev/null || true
 count_file="${dir}/claude_call_count"
 count=\$(cat "\$count_file" 2>/dev/null || echo 0)
 count=\$((count + 1))
@@ -105,12 +106,13 @@ _write_verify_claude_stub() {
   mkdir -p "$dir/bin"
   cat > "$dir/bin/claude" << EOF
 #!/bin/sh
+read -r _line 2>/dev/null || true
 count_file="${dir}/claude_call_count"
 count=\$(cat "\$count_file" 2>/dev/null || echo 0)
 count=\$((count + 1))
 printf '%s\n' "\$count" > "\$count_file"
 
-cat > "${dir}/claude_stdin_\${count}" 2>/dev/null || true
+printf '%s\n' "\$_line" > "${dir}/claude_stdin_\${count}" 2>/dev/null || true
 
 exit_codes_file="${dir}/claude_exit_codes"
 exit_code=0

--- a/tests/test_permission_handler.sh
+++ b/tests/test_permission_handler.sh
@@ -1,0 +1,178 @@
+#!/usr/bin/env bats
+# bats file_tags=permission_handler
+
+# Tests for lib/permission_handler.sh — permission_filter, response builders, field extraction
+# Note: bats uses FD 3 internally, so we must not use exec 3>&- in teardown.
+# For permission_filter tests, we set PERMISSION_RESPONSE_FD and use FD 7.
+
+setup() {
+  source "${BATS_TEST_DIRNAME}/../lib/ui.sh"
+  source "${BATS_TEST_DIRNAME}/../lib/permission_handler.sh"
+  VERBOSE_MODE=false
+  SKIP_PERMISSIONS=true
+  _tmpdir="$BATS_TEST_TMPDIR"
+}
+
+teardown() { :; }
+
+# --- _extract_field() ---
+
+@test "_extract_field: extracts simple string field" {
+  local json='{"request_id":"req_123","type":"control_request"}'
+  run _extract_field "$json" "request_id"
+  [ "$status" -eq 0 ]
+  [ "$output" = "req_123" ]
+}
+
+@test "_extract_field: extracts nested-looking field" {
+  local json='{"type":"control_request","request_id":"abc-def-456"}'
+  run _extract_field "$json" "request_id"
+  [ "$status" -eq 0 ]
+  [ "$output" = "abc-def-456" ]
+}
+
+@test "_extract_field: returns empty for missing field" {
+  local json='{"type":"control_request"}'
+  run _extract_field "$json" "request_id"
+  [ "$status" -eq 0 ]
+  [ "$output" = "" ]
+}
+
+@test "_extract_field: handles escaped quotes in value" {
+  local json='{"name":"foo\"bar","type":"test"}'
+  run _extract_field "$json" "name"
+  [ "$status" -eq 0 ]
+  [ -n "$output" ]
+}
+
+# --- _build_stream_message() ---
+
+@test "_build_stream_message: produces valid JSON structure" {
+  run _build_stream_message "Hello world"
+  [ "$status" -eq 0 ]
+  echo "$output" | grep -q '"type":"user"'
+  echo "$output" | grep -q '"role":"user"'
+  echo "$output" | grep -q '"content":"Hello world"'
+  echo "$output" | grep -q '"session_id"'
+}
+
+@test "_build_stream_message: escapes special characters" {
+  run _build_stream_message 'Line 1
+Line 2	with tab and "quotes"'
+  [ "$status" -eq 0 ]
+  echo "$output" | grep -q '\\n'
+  echo "$output" | grep -q '\\t'
+  echo "$output" | grep -q '\\"'
+}
+
+@test "_build_stream_message: handles backslashes" {
+  run _build_stream_message 'path\to\file'
+  [ "$status" -eq 0 ]
+  echo "$output" | grep -q '\\\\'
+}
+
+# --- _build_deny_response() ---
+
+@test "_build_deny_response: builds valid deny JSON" {
+  local request='{"type":"control_request","request_id":"req_abc123","request":{"type":"can_use_tool","tool_name":"Write","input":{"file_path":"/tmp/test"}}}'
+  run _build_deny_response "$request"
+  [ "$status" -eq 0 ]
+  echo "$output" | grep -q '"type":"control_response"'
+  echo "$output" | grep -q '"request_id":"req_abc123"'
+  echo "$output" | grep -q '"behavior":"deny"'
+}
+
+# --- _build_allow_response() ---
+
+@test "_build_allow_response: builds valid allow JSON with updatedInput" {
+  command -v node >/dev/null 2>&1 || skip "node.js not available"
+  local request='{"type":"control_request","request_id":"req_xyz","request":{"type":"can_use_tool","tool_name":"Write","input":{"file_path":"/tmp/test.txt","content":"hello"}}}'
+  run _build_allow_response "$request"
+  [ "$status" -eq 0 ]
+  echo "$output" | grep -q '"type":"control_response"'
+  echo "$output" | grep -q '"request_id":"req_xyz"'
+  echo "$output" | grep -q '"behavior":"allow"'
+  echo "$output" | grep -q '"updatedInput"'
+}
+
+@test "_build_allow_response: echoes back original input in updatedInput" {
+  command -v node >/dev/null 2>&1 || skip "node.js not available"
+  local request='{"type":"control_request","request_id":"req_001","request":{"type":"can_use_tool","tool_name":"Edit","input":{"file_path":"src/main.sh","old_string":"foo","new_string":"bar"}}}'
+  result=$(_build_allow_response "$request")
+  echo "$result" | node -e "
+    const r=JSON.parse(require('fs').readFileSync('/dev/stdin','utf8'));
+    const inp=r.response.response.updatedInput;
+    if(inp.file_path!=='src/main.sh') process.exit(1);
+    if(inp.old_string!=='foo') process.exit(1);
+    if(inp.new_string!=='bar') process.exit(1);
+  "
+}
+
+# --- permission_filter() ---
+# Uses subshell with redirection to avoid bats FD conflicts.
+# permission_filter reads stdin, writes pass-through to stdout, writes responses to FD 3.
+# We redirect FD 3 to a file in a subshell wrapper.
+
+_run_filter() {
+  # Args: stdin content via pipe, FD output file path as $1
+  local _fd_file="$1"
+  (
+    exec 7>"$_fd_file"
+    permission_filter
+    exec 7>&-
+  )
+}
+
+@test "permission_filter: passes non-control events through unchanged" {
+  local input='{"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"hello"}]}}
+{"type":"tool_use","name":"Edit","input":{},"id":"toolu_001"}
+{"type":"result","total_cost_usd":0.01}'
+  local fd3_out="$_tmpdir/fd3_pass"
+  result=$(printf '%s\n' "$input" | _run_filter "$fd3_out")
+  [ "$(printf '%s\n' "$result" | wc -l | tr -d ' ')" -eq 3 ]
+  echo "$result" | grep -q '"type":"assistant"'
+  echo "$result" | grep -q '"type":"tool_use"'
+  echo "$result" | grep -q '"type":"result"'
+}
+
+@test "permission_filter: intercepts control_request and does not pass it downstream" {
+  command -v node >/dev/null 2>&1 || skip "node.js not available"
+  SKIP_PERMISSIONS=true
+  local fd3_out="$_tmpdir/fd3_intercept"
+  local input='{"type":"control_request","request_id":"req_002","request":{"type":"can_use_tool","tool_name":"Write","input":{"file_path":"/tmp/x"}}}
+{"type":"assistant","message":{"content":[{"type":"text","text":"done"}]}}'
+  result=$(printf '%s\n' "$input" | _run_filter "$fd3_out")
+  # Only the assistant event should pass through
+  [ "$(printf '%s\n' "$result" | wc -l | tr -d ' ')" -eq 1 ]
+  echo "$result" | grep -q '"type":"assistant"'
+}
+
+@test "permission_filter: ignores keep_alive events" {
+  local fd3_out="$_tmpdir/fd3_keepalive"
+  local input='{"type":"keep_alive","timestamp":"2026-01-01T00:00:00Z"}
+{"type":"assistant","message":{"content":[{"type":"text","text":"done"}]}}'
+  result=$(printf '%s\n' "$input" | _run_filter "$fd3_out")
+  [ "$(printf '%s\n' "$result" | wc -l | tr -d ' ')" -eq 1 ]
+  echo "$result" | grep -q '"type":"assistant"'
+}
+
+@test "permission_filter: ignores control_cancel_request events" {
+  local fd3_out="$_tmpdir/fd3_cancel"
+  local input='{"type":"control_cancel_request","request_id":"req_003"}
+{"type":"result","total_cost_usd":0.01}'
+  result=$(printf '%s\n' "$input" | _run_filter "$fd3_out")
+  [ "$(printf '%s\n' "$result" | wc -l | tr -d ' ')" -eq 1 ]
+  echo "$result" | grep -q '"type":"result"'
+}
+
+@test "permission_filter: auto-approve writes allow response to permission FD" {
+  command -v node >/dev/null 2>&1 || skip "node.js not available"
+  SKIP_PERMISSIONS=true
+  local fd3_out="$_tmpdir/fd3_allow"
+  local input='{"type":"control_request","request_id":"req_005","request":{"type":"can_use_tool","tool_name":"Write","input":{"file_path":"/tmp/test.txt","content":"hi"}}}'
+  printf '%s\n' "$input" | _run_filter "$fd3_out" >/dev/null
+  [ -f "$fd3_out" ]
+  grep -q '"type":"control_response"' "$fd3_out"
+  grep -q '"behavior":"allow"' "$fd3_out"
+  grep -q '"updatedInput"' "$fd3_out"
+}

--- a/tests/test_refactor.sh
+++ b/tests/test_refactor.sh
@@ -71,7 +71,7 @@ setup() {
   mkdir -p "$TEST_DIR/bin"
   cat > "$TEST_DIR/bin/claude" << 'STUB'
 #!/bin/sh
-cat > /dev/null
+read -r _discard 2>/dev/null || true
 printf '{"type":"content_block_start","content_block":{"type":"text","text":"Refactoring..."}}\n'
 printf '{"type":"tool_use","name":"Bash","input":{"command":"echo refactored"}}\n'
 printf '{"type":"content_block_start","content_block":{"type":"text","text":"Done.\nVERIFICATION_PASSED\n"}}\n'
@@ -110,7 +110,7 @@ teardown() {
   # Stub that always fails (non-zero exit), counts calls
   cat > "$TEST_DIR/bin/claude" << STUB
 #!/bin/sh
-cat > /dev/null
+read -r _discard 2>/dev/null || true
 n=\$(cat "$TEST_DIR/call_count")
 n=\$((n + 1))
 echo "\$n" > "$TEST_DIR/call_count"
@@ -138,7 +138,7 @@ STUB
 
   cat > "$TEST_DIR/bin/claude" << STUB
 #!/bin/sh
-cat > /dev/null
+read -r _discard 2>/dev/null || true
 n=\$(cat "$TEST_DIR/call_count")
 n=\$((n + 1))
 echo "\$n" > "$TEST_DIR/call_count"
@@ -197,7 +197,7 @@ STUB
   # First call: refactor (makes commit). Second call: verify (passes).
   cat > "$TEST_DIR/bin/claude" << STUB
 #!/bin/sh
-cat > /dev/null
+read -r _discard 2>/dev/null || true
 n=\$(cat "$TEST_DIR/call_count")
 n=\$((n + 1))
 echo "\$n" > "$TEST_DIR/call_count"
@@ -237,7 +237,7 @@ STUB
   # Stub that always exits non-zero
   cat > "$TEST_DIR/bin/claude" << 'STUB'
 #!/bin/sh
-cat > /dev/null
+read -r _discard 2>/dev/null || true
 printf '{"type":"content_block_start","content_block":{"type":"text","text":"Crash"}}\n'
 exit 1
 STUB
@@ -258,7 +258,7 @@ STUB
   # Stub that exits 0 but makes no commits
   cat > "$TEST_DIR/bin/claude" << 'STUB'
 #!/bin/sh
-cat > /dev/null
+read -r _discard 2>/dev/null || true
 printf '{"type":"tool_use","name":"Bash","input":{"command":"echo nothing to do"}}\n'
 printf '{"type":"content_block_start","content_block":{"type":"text","text":"Code is well-structured, nothing to refactor.\n"}}\n'
 exit 0
@@ -296,7 +296,7 @@ STUB
   # Stub that outputs tool_use + VERIFICATION_PASSED
   cat > "$TEST_DIR/bin/claude" << 'STUB'
 #!/bin/sh
-cat > /dev/null
+read -r _discard 2>/dev/null || true
 printf '{"type":"tool_use","name":"Bash","input":{"command":"git diff HEAD~1"}}\n'
 printf '{"type":"content_block_start","content_block":{"type":"text","text":"Refactoring is clean.\nVERIFICATION_PASSED\n"}}\n'
 exit 0
@@ -336,7 +336,7 @@ STUB
   # Stub: first call = refactor (no-op), second call = verify
   cat > "$TEST_DIR/bin/claude" << 'STUB'
 #!/bin/sh
-cat > /dev/null
+read -r _discard 2>/dev/null || true
 printf '{"type":"tool_use","name":"Bash","input":{"command":"echo nothing"}}\n'
 printf '{"type":"content_block_start","content_block":{"type":"text","text":"Nothing to refactor.\n"}}\n'
 exit 0
@@ -362,7 +362,7 @@ STUB
   # Stub that exits 0 but makes no commits (nothing to refactor)
   cat > "$TEST_DIR/bin/claude" << 'STUB'
 #!/bin/sh
-cat > /dev/null
+read -r _discard 2>/dev/null || true
 printf '{"type":"tool_use","name":"Bash","input":{"command":"echo nothing"}}\n'
 printf '{"type":"content_block_start","content_block":{"type":"text","text":"Nothing to refactor.\n"}}\n'
 exit 0
@@ -386,7 +386,7 @@ STUB
   echo "0" > "$TEST_DIR/call_count"
   cat > "$TEST_DIR/bin/claude" << STUB
 #!/bin/sh
-cat > /dev/null
+read -r _discard 2>/dev/null || true
 n=\$(cat "$TEST_DIR/call_count")
 n=\$((n + 1))
 echo "\$n" > "$TEST_DIR/call_count"
@@ -421,7 +421,7 @@ STUB
   echo "0" > "$TEST_DIR/call_count"
   cat > "$TEST_DIR/bin/claude" << STUB
 #!/bin/sh
-cat > /dev/null
+read -r _discard 2>/dev/null || true
 n=\$(cat "$TEST_DIR/call_count")
 n=\$((n + 1))
 echo "\$n" > "$TEST_DIR/call_count"
@@ -468,7 +468,7 @@ STUB
   # Stub that exits 0, makes no commits (nothing to refactor)
   cat > "$TEST_DIR/bin/claude" << 'STUB'
 #!/bin/sh
-cat > /dev/null
+read -r _discard 2>/dev/null || true
 printf '{"type":"tool_use","name":"Bash","input":{"command":"echo nothing"}}\n'
 printf '{"type":"content_block_start","content_block":{"type":"text","text":"Nothing to refactor.\n"}}\n'
 exit 0
@@ -497,7 +497,7 @@ STUB
   # Stub that exits 0, makes no commits
   cat > "$TEST_DIR/bin/claude" << 'STUB'
 #!/bin/sh
-cat > /dev/null
+read -r _discard 2>/dev/null || true
 printf '{"type":"tool_use","name":"Bash","input":{"command":"echo nothing"}}\n'
 printf '{"type":"content_block_start","content_block":{"type":"text","text":"Nothing to refactor.\n"}}\n'
 exit 0
@@ -555,7 +555,7 @@ STUB
   # Stub: refactor call modifies files but does NOT commit; verify passes
   cat > "$TEST_DIR/bin/claude" << STUB
 #!/bin/sh
-cat > /dev/null
+read -r _discard 2>/dev/null || true
 n=\$(cat "$TEST_DIR/call_count")
 n=\$((n + 1))
 echo "\$n" > "$TEST_DIR/call_count"
@@ -596,7 +596,7 @@ STUB
   # Stub: first call crashes with uncommitted changes, second call succeeds with verify
   cat > "$TEST_DIR/bin/claude" << STUB
 #!/bin/sh
-cat > /dev/null
+read -r _discard 2>/dev/null || true
 n=\$(cat "$TEST_DIR/call_count")
 n=\$((n + 1))
 echo "\$n" > "$TEST_DIR/call_count"
@@ -651,7 +651,7 @@ STUB
   # Stub that always fails — copies PROGRESS.md at each attempt to capture status
   cat > "$TEST_DIR/bin/claude" << STUB
 #!/bin/sh
-cat > /dev/null
+read -r _discard 2>/dev/null || true
 n=\$(cat "$TEST_DIR/call_count")
 n=\$((n + 1))
 echo "\$n" > "$TEST_DIR/call_count"
@@ -686,7 +686,7 @@ STUB
   # Stub that always fails
   cat > "$TEST_DIR/bin/claude" << STUB
 #!/bin/sh
-cat > /dev/null
+read -r _discard 2>/dev/null || true
 n=\$(cat "$TEST_DIR/call_count")
 n=\$((n + 1))
 echo "\$n" > "$TEST_DIR/call_count"
@@ -713,8 +713,9 @@ STUB
   # Stub: first call fails with error output, second call captures prompt
   cat > "$TEST_DIR/bin/claude" << STUB
 #!/bin/sh
-# Save the prompt from stdin
-cat > "$TEST_DIR/prompt_\$(cat "$TEST_DIR/call_count")"
+# Save the prompt from stdin (single line from FIFO)
+read -r _line 2>/dev/null || true
+printf '%s\n' "\$_line" > "$TEST_DIR/prompt_\$(cat "$TEST_DIR/call_count")"
 n=\$(cat "$TEST_DIR/call_count")
 n=\$((n + 1))
 echo "\$n" > "$TEST_DIR/call_count"
@@ -771,7 +772,7 @@ STUB
   # Stub that captures the prompt and passes
   cat > "$TEST_DIR/bin/claude" << STUB
 #!/bin/sh
-cat > "$TEST_DIR/verify_prompt"
+read -r _line 2>/dev/null || true; printf '%s\n' "$_line" > "$TEST_DIR/verify_prompt"
 printf '{"type":"tool_use","name":"Bash","input":{"command":"echo ok"}}\n'
 printf '{"type":"content_block_start","content_block":{"type":"text","text":"All good.\\nVERIFICATION_PASSED\\n"}}\n'
 exit 0
@@ -813,7 +814,7 @@ STUB
   # Stub that exits 0, makes no commits (nothing to refactor)
   cat > "$TEST_DIR/bin/claude" << 'STUB'
 #!/bin/sh
-cat > /dev/null
+read -r _discard 2>/dev/null || true
 printf '{"type":"tool_use","name":"Bash","input":{"command":"echo nothing"}}\n'
 printf '{"type":"content_block_start","content_block":{"type":"text","text":"Nothing to refactor.\n"}}\n'
 exit 0
@@ -860,7 +861,7 @@ STUB
   # Stub that exits 0 but makes no code changes (only reads files)
   cat > "$TEST_DIR/bin/claude" << 'STUB'
 #!/bin/sh
-cat > /dev/null
+read -r _discard 2>/dev/null || true
 printf '{"type":"tool_use","name":"Read","input":{"file_path":"file.txt"}}\n'
 printf '{"type":"content_block_start","content_block":{"type":"text","text":"Code looks good, nothing to refactor.\n"}}\n'
 exit 0
@@ -892,7 +893,7 @@ STUB
   # Stub: attempt 1 crashes after writing a source file, attempt 2 exits 0 with no writes
   cat > "$TEST_DIR/bin/claude" << STUB
 #!/bin/sh
-cat > /dev/null
+read -r _discard 2>/dev/null || true
 n=\$(cat "$TEST_DIR/call_count")
 n=\$((n + 1))
 echo "\$n" > "$TEST_DIR/call_count"
@@ -939,7 +940,7 @@ STUB
   # Stub that captures the prompt
   cat > "$TEST_DIR/bin/claude" << STUB
 #!/bin/sh
-cat > "$TEST_DIR/verify_prompt_captured"
+read -r _line 2>/dev/null || true; printf '%s\n' "$_line" > "$TEST_DIR/verify_prompt_captured"
 printf '{"type":"tool_use","name":"Bash","input":{"command":"echo ok"}}\n'
 printf '{"type":"content_block_start","content_block":{"type":"text","text":"All good.\\nVERIFICATION_PASSED\\n"}}\n'
 exit 0
@@ -962,7 +963,7 @@ STUB
 @test "verify_refactor: prompt mentions regression-based verification" {
   cat > "$TEST_DIR/bin/claude" << STUB
 #!/bin/sh
-cat > "$TEST_DIR/verify_prompt_captured"
+read -r _line 2>/dev/null || true; printf '%s\n' "$_line" > "$TEST_DIR/verify_prompt_captured"
 printf '{"type":"tool_use","name":"Bash","input":{"command":"echo ok"}}\n'
 printf '{"type":"content_block_start","content_block":{"type":"text","text":"All good.\\nVERIFICATION_PASSED\\n"}}\n'
 exit 0
@@ -1000,7 +1001,7 @@ STUB
 
   cat > "$TEST_DIR/bin/claude" << STUB
 #!/bin/sh
-cat > /dev/null
+read -r _discard 2>/dev/null || true
 n=\$(cat "$TEST_DIR/call_count")
 n=\$((n + 1))
 echo "\$n" > "$TEST_DIR/call_count"
@@ -1040,7 +1041,7 @@ STUB
   # Stub that always fails (non-zero exit), counts calls
   cat > "$TEST_DIR/bin/claude" << STUB
 #!/bin/sh
-cat > /dev/null
+read -r _discard 2>/dev/null || true
 n=\$(cat "$TEST_DIR/call_count")
 n=\$((n + 1))
 echo "\$n" > "$TEST_DIR/call_count"
@@ -1069,7 +1070,7 @@ STUB
   # Stub that captures progress at attempt 1 then fails
   cat > "$TEST_DIR/bin/claude" << STUB
 #!/bin/sh
-cat > /dev/null
+read -r _discard 2>/dev/null || true
 n=\$(cat "$TEST_DIR/call_count")
 n=\$((n + 1))
 echo "\$n" > "$TEST_DIR/call_count"
@@ -1098,7 +1099,7 @@ STUB
   # then verify passes
   cat > "$TEST_DIR/bin/claude" << STUB
 #!/bin/sh
-cat > /dev/null
+read -r _discard 2>/dev/null || true
 n=\$(cat "$TEST_DIR/call_count")
 n=\$((n + 1))
 echo "\$n" > "$TEST_DIR/call_count"
@@ -1144,7 +1145,7 @@ STUB
   # Stub that captures progress at each attempt then fails
   cat > "$TEST_DIR/bin/claude" << STUB
 #!/bin/sh
-cat > /dev/null
+read -r _discard 2>/dev/null || true
 n=\$(cat "$TEST_DIR/call_count")
 n=\$((n + 1))
 echo "\$n" > "$TEST_DIR/call_count"

--- a/tests/test_retry.sh
+++ b/tests/test_retry.sh
@@ -145,10 +145,10 @@ teardown() { :; }
   [ "$status" -eq 0 ]
 }
 
-@test "is_quota_error: detects 'overloaded'" {
+@test "is_quota_error: does NOT match 'overloaded' (moved to is_overload_error)" {
   printf 'The API is overloaded, please try again later.\n' > "$_log"
   run is_quota_error "$_log"
-  [ "$status" -eq 0 ]
+  [ "$status" -eq 1 ]
 }
 
 # --- is_permission_error() ---
@@ -1023,4 +1023,186 @@ teardown() { :; }
   rm -f ".claudeloop/signals/phase-99.md"
   run has_signal_file "99"
   [ "$status" -eq 1 ]
+}
+
+# --- is_overload_error() ---
+
+@test "is_overload_error: nonexistent file returns 1" {
+  run is_overload_error "/nonexistent/path/phase-99.log"
+  [ "$status" -eq 1 ]
+}
+
+@test "is_overload_error: clean output returns 1" {
+  printf 'All good, task completed.\n' > "$_log"
+  run is_overload_error "$_log"
+  [ "$status" -eq 1 ]
+}
+
+@test "is_overload_error: detects 'overloaded'" {
+  printf 'The API is overloaded, please try again later.\n' > "$_log"
+  run is_overload_error "$_log"
+  [ "$status" -eq 0 ]
+}
+
+@test "is_overload_error: detects 'overloaded_error' in raw JSON" {
+  local _raw="$BATS_TEST_TMPDIR/raw.json"
+  printf '{"error":{"type":"overloaded_error","message":"Overloaded"}}\n' > "$_raw"
+  printf 'All good\n' > "$_log"
+  run is_overload_error "$_log" "$_raw"
+  [ "$status" -eq 0 ]
+}
+
+@test "is_overload_error: detects 529 status" {
+  printf 'HTTP 529 — API overloaded\n' > "$_log"
+  run is_overload_error "$_log"
+  [ "$status" -eq 0 ]
+}
+
+# --- is_server_error() ---
+
+@test "is_server_error: nonexistent file returns 1" {
+  run is_server_error "/nonexistent/path/phase-99.log"
+  [ "$status" -eq 1 ]
+}
+
+@test "is_server_error: clean output returns 1" {
+  printf 'All good, task completed.\n' > "$_log"
+  run is_server_error "$_log"
+  [ "$status" -eq 1 ]
+}
+
+@test "is_server_error: detects 'api_error'" {
+  printf 'Error: api_error\n' > "$_log"
+  run is_server_error "$_log"
+  [ "$status" -eq 0 ]
+}
+
+@test "is_server_error: detects 'internal_server_error'" {
+  printf 'Error: internal_server_error from API\n' > "$_log"
+  run is_server_error "$_log"
+  [ "$status" -eq 0 ]
+}
+
+@test "is_server_error: detects 'Server error'" {
+  printf 'Server error: please try again\n' > "$_log"
+  run is_server_error "$_log"
+  [ "$status" -eq 0 ]
+}
+
+@test "is_server_error: detects HTTP 500" {
+  printf 'HTTP 500 Internal Server Error\n' > "$_log"
+  run is_server_error "$_log"
+  [ "$status" -eq 0 ]
+}
+
+@test "is_server_error: detects HTTP 502" {
+  printf 'HTTP 502 Bad Gateway\n' > "$_log"
+  run is_server_error "$_log"
+  [ "$status" -eq 0 ]
+}
+
+@test "is_server_error: detects HTTP 503" {
+  printf 'HTTP 503 Service Unavailable\n' > "$_log"
+  run is_server_error "$_log"
+  [ "$status" -eq 0 ]
+}
+
+@test "is_server_error: checks raw JSON log as fallback" {
+  local _raw="$BATS_TEST_TMPDIR/raw.json"
+  printf 'All good\n' > "$_log"
+  printf '{"error":{"type":"api_error","message":"Internal server error"}}\n' > "$_raw"
+  run is_server_error "$_log" "$_raw"
+  [ "$status" -eq 0 ]
+}
+
+# --- is_timeout_error() ---
+
+@test "is_timeout_error: nonexistent file returns 1" {
+  run is_timeout_error "/nonexistent/path/phase-99.log"
+  [ "$status" -eq 1 ]
+}
+
+@test "is_timeout_error: clean output returns 1" {
+  printf 'All good, task completed.\n' > "$_log"
+  run is_timeout_error "$_log"
+  [ "$status" -eq 1 ]
+}
+
+@test "is_timeout_error: detects 'request_timeout'" {
+  printf 'Error: request_timeout\n' > "$_log"
+  run is_timeout_error "$_log"
+  [ "$status" -eq 0 ]
+}
+
+@test "is_timeout_error: detects HTTP 408" {
+  printf 'HTTP 408 Request Timeout\n' > "$_log"
+  run is_timeout_error "$_log"
+  [ "$status" -eq 0 ]
+}
+
+@test "is_timeout_error: detects 'request timed out'" {
+  printf 'The request timed out waiting for a response\n' > "$_log"
+  run is_timeout_error "$_log"
+  [ "$status" -eq 0 ]
+}
+
+# --- is_rate_limit_error() (renamed, no longer matches overloaded) ---
+
+@test "is_rate_limit_error: detects 'rate_limit_error'" {
+  printf 'type: rate_limit_error\n' > "$_log"
+  run is_rate_limit_error "$_log"
+  [ "$status" -eq 0 ]
+}
+
+@test "is_rate_limit_error: detects 'usage limit'" {
+  printf 'Error: usage limit exceeded\n' > "$_log"
+  run is_rate_limit_error "$_log"
+  [ "$status" -eq 0 ]
+}
+
+@test "is_rate_limit_error: does NOT match 'overloaded'" {
+  printf 'The API is overloaded, please try again later.\n' > "$_log"
+  run is_rate_limit_error "$_log"
+  [ "$status" -eq 1 ]
+}
+
+@test "is_quota_error: still works as alias for backward compat" {
+  printf 'Error: usage limit exceeded\n' > "$_log"
+  run is_quota_error "$_log"
+  [ "$status" -eq 0 ]
+}
+
+# --- is_auth_error() expanded ---
+
+@test "is_auth_error: detects permission_error" {
+  printf 'Error: permission_error — your key cannot access this resource\n' > "$_log"
+  run is_auth_error "$_log"
+  [ "$status" -eq 0 ]
+}
+
+@test "is_auth_error: detects not_found_error" {
+  printf 'Error: not_found_error — model not available\n' > "$_log"
+  run is_auth_error "$_log"
+  [ "$status" -eq 0 ]
+}
+
+# --- fail_reason_hint: permission_denied ---
+
+@test "fail_reason_hint: permission_denied returns hint about skipping denied files" {
+  run fail_reason_hint "permission_denied"
+  [ "$status" -eq 0 ]
+  [ -n "$output" ]
+  echo "$output" | grep -qi "permission\|denied\|skip"
+}
+
+# --- escalate_strategy: permission_denied ---
+
+@test "escalate_strategy: escalates for permission_denied at consec=3" {
+  run escalate_strategy "standard" "permission_denied" 3
+  [ "$output" = "stripped" ]
+}
+
+@test "escalate_strategy: escalates for permission_denied at consec=5" {
+  run escalate_strategy "standard" "permission_denied" 5
+  [ "$output" = "targeted" ]
 }

--- a/tests/test_verify.sh
+++ b/tests/test_verify.sh
@@ -16,6 +16,7 @@ setup() {
   . "$CLAUDELOOP_DIR/lib/phase_state.sh"
   . "$CLAUDELOOP_DIR/lib/ui.sh"
   . "$CLAUDELOOP_DIR/lib/stream_processor.sh"
+  . "$CLAUDELOOP_DIR/lib/permission_handler.sh"
   . "$CLAUDELOOP_DIR/lib/verify.sh"
 
   # Set up minimal phase data
@@ -45,8 +46,8 @@ setup() {
   mkdir -p "$TEST_DIR/bin"
   cat > "$TEST_DIR/bin/claude" << 'STUB'
 #!/bin/sh
-# Read stdin (prompt) to /dev/null
-cat > /dev/null
+# Read first line from stdin (stream-json message) and discard
+read -r _discard 2>/dev/null || true
 printf '{"type":"content_block_start","content_block":{"type":"text","text":"Running verification..."}}\n'
 printf '{"type":"tool_use","name":"Bash","input":{"command":"git diff"}}\n'
 printf '{"type":"content_block_start","content_block":{"type":"text","text":"All checks passed.\nVERIFICATION_PASSED\n"}}\n'
@@ -101,7 +102,7 @@ teardown() {
   # Replace stub with one that fails
   cat > "$TEST_DIR/bin/claude" << 'STUB'
 #!/bin/sh
-cat > /dev/null
+read -r _discard 2>/dev/null || true
 printf '{"type":"tool_use","name":"Bash","input":{"command":"npm test"}}\n'
 printf '{"type":"content_block_start","content_block":{"type":"text","text":"Tests failed!"}}\n'
 exit 1
@@ -120,7 +121,7 @@ STUB
   # Stub exits 0, outputs text mentioning "Bash" but no "type":"tool_use" JSON events
   cat > "$TEST_DIR/bin/claude" << 'STUB'
 #!/bin/sh
-cat > /dev/null
+read -r _discard 2>/dev/null || true
 printf '{"type":"content_block_start","content_block":{"type":"text","text":"I would run Bash but skipping.\nVERIFICATION_PASSED\n"}}\n'
 exit 0
 STUB
@@ -150,7 +151,7 @@ STUB
   # Replace claude stub with one that captures stdin
   cat > "$TEST_DIR/bin/claude" << 'STUB'
 #!/bin/sh
-cat > /tmp/verify_prompt_capture
+IFS= read -r _line 2>/dev/null; printf '%s\n' "$_line" > /tmp/verify_prompt_capture
 printf '{"type":"tool_use","name":"Bash","input":{"command":"git diff"}}\n'
 printf '{"type":"content_block_start","content_block":{"type":"text","text":"All checks passed.\nVERIFICATION_PASSED\n"}}\n'
 exit 0
@@ -169,7 +170,7 @@ STUB
     > ".claudeloop/logs/phase-1.log"
   cat > "$TEST_DIR/bin/claude" << 'STUB'
 #!/bin/sh
-cat > /tmp/verify_prompt_capture2
+IFS= read -r _line 2>/dev/null; printf '%s\n' "$_line" > /tmp/verify_prompt_capture2
 printf '{"type":"tool_use","name":"Bash","input":{"command":"git diff"}}\n'
 printf '{"type":"content_block_start","content_block":{"type":"text","text":"VERIFICATION_PASSED\n"}}\n'
 exit 0
@@ -184,7 +185,7 @@ STUB
   VERIFY_PHASES=true
   cat > "$TEST_DIR/bin/claude" << 'STUB'
 #!/bin/sh
-cat > /tmp/verify_prompt_verdict
+IFS= read -r _line 2>/dev/null; printf '%s\n' "$_line" > /tmp/verify_prompt_verdict
 printf '{"type":"tool_use","name":"Bash","input":{"command":"git diff"}}\n'
 printf '{"type":"content_block_start","content_block":{"type":"text","text":"VERIFICATION_PASSED\n"}}\n'
 exit 0
@@ -200,13 +201,13 @@ STUB
 # SKIP_PERMISSIONS pass-through
 # =============================================================================
 
-@test "verify_phase: respects SKIP_PERMISSIONS" {
+@test "verify_phase: uses bidirectional stdio protocol flags" {
   VERIFY_PHASES=true
   SKIP_PERMISSIONS=true
   # Replace claude stub with one that captures args
   cat > "$TEST_DIR/bin/claude" << 'STUB'
 #!/bin/sh
-cat > /dev/null
+read -r _discard 2>/dev/null || true
 printf '%s\n' "$*" > /tmp/verify_args_capture
 printf '{"type":"tool_use","name":"Bash","input":{"command":"git diff"}}\n'
 printf '{"type":"content_block_start","content_block":{"type":"text","text":"VERIFICATION_PASSED\n"}}\n'
@@ -214,7 +215,9 @@ exit 0
 STUB
   chmod +x "$TEST_DIR/bin/claude"
   verify_phase "1" ".claudeloop/logs/phase-1.log"
-  grep -q "dangerously-skip-permissions" /tmp/verify_args_capture
+  # Should use stream-json input and permission-prompt-tool stdio
+  grep -q "permission-prompt-tool" /tmp/verify_args_capture
+  grep -q "input-format" /tmp/verify_args_capture
   rm -f /tmp/verify_args_capture
 }
 
@@ -227,7 +230,7 @@ STUB
   MAX_PHASE_TIME=0
   cat > "$TEST_DIR/bin/claude" << 'STUB'
 #!/bin/sh
-cat > /dev/null
+read -r _discard 2>/dev/null || true
 printf '{"type":"tool_use","name":"Bash","input":{"command":"git diff"}}\n'
 sleep 30
 exit 0
@@ -273,7 +276,7 @@ STUB
   : > "$LIVE_LOG"
   cat > "$TEST_DIR/bin/claude" << 'STUB'
 #!/bin/sh
-cat > /dev/null
+read -r _discard 2>/dev/null || true
 printf '{"type":"content_block_start","content_block":{"type":"text","text":"Running verification..."}}\n'
 printf '{"type":"tool_use","name":"Bash","input":{"command":"bats tests/test_parser.sh"}}\n'
 printf '{"type":"content_block_start","content_block":{"type":"text","text":"All checks passed.\nVERIFICATION_PASSED\n"}}\n'
@@ -306,7 +309,7 @@ STUB
   VERIFY_PHASES=true
   cat > "$TEST_DIR/bin/claude" << 'STUB'
 #!/bin/sh
-cat > /dev/null
+read -r _discard 2>/dev/null || true
 printf '{"type":"tool_use","name":"Bash","input":{"command":"npm test"}}\n'
 printf '{"type":"content_block_start","content_block":{"type":"text","text":"Tests are broken.\nVERIFICATION_FAILED\n"}}\n'
 exit 0
@@ -320,7 +323,7 @@ STUB
   VERIFY_PHASES=true
   cat > "$TEST_DIR/bin/claude" << 'STUB'
 #!/bin/sh
-cat > /dev/null
+read -r _discard 2>/dev/null || true
 printf '{"type":"tool_use","name":"Bash","input":{"command":"git diff"}}\n'
 printf '{"type":"content_block_start","content_block":{"type":"text","text":"Checking things..."}}\n'
 exit 0
@@ -334,7 +337,7 @@ STUB
   VERIFY_PHASES=true
   cat > "$TEST_DIR/bin/claude" << 'STUB'
 #!/bin/sh
-cat > /dev/null
+read -r _discard 2>/dev/null || true
 printf '{"type":"tool_use","name":"Bash","input":{"command":"npm test"}}\n'
 printf '{"type":"content_block_start","content_block":{"type":"text","text":"Initially I thought VERIFICATION_PASSED but actually\nVERIFICATION_FAILED tests broken\n"}}\n'
 exit 0
@@ -348,7 +351,7 @@ STUB
   VERIFY_PHASES=true
   cat > "$TEST_DIR/bin/claude" << 'STUB'
 #!/bin/sh
-cat > /dev/null
+read -r _discard 2>/dev/null || true
 printf '{"type":"content_block_start","content_block":{"type":"text","text":"I would use Bash to run tests and Read files.\nVERIFICATION_PASSED\n"}}\n'
 exit 0
 STUB
@@ -368,7 +371,7 @@ STUB
   # Stub that sleeps longer than VERIFY_TIMEOUT to prove timeout is applied
   cat > "$TEST_DIR/bin/claude" << 'STUB'
 #!/bin/sh
-cat > /dev/null
+read -r _discard 2>/dev/null || true
 printf '{"type":"tool_use","name":"Bash","input":{"command":"git diff"}}\n'
 sleep 5
 exit 0
@@ -389,7 +392,7 @@ STUB
   MAX_PHASE_TIME=60
   cat > "$TEST_DIR/bin/claude" << 'STUB'
 #!/bin/sh
-cat > /dev/null
+read -r _discard 2>/dev/null || true
 printf '{"type":"tool_use","name":"Bash","input":{"command":"git diff"}}\n'
 sleep 5
 exit 0
@@ -474,7 +477,7 @@ STUB
   # We simulate this by having the claude process killed before writing exit code
   cat > "$TEST_DIR/bin/claude" << 'STUB'
 #!/bin/sh
-cat > /dev/null
+read -r _discard 2>/dev/null || true
 printf '{"type":"tool_use","name":"Bash","input":{"command":"git diff"}}\n'
 printf '{"type":"content_block_start","content_block":{"type":"text","text":"VERIFICATION_PASSED\n"}}\n'
 # Exit normally — we rely on the exit code guard for empty/corrupt _exit_tmp

--- a/tests/test_wizard_config.sh
+++ b/tests/test_wizard_config.sh
@@ -34,6 +34,7 @@ PLAN
   mkdir -p "$TEST_DIR/bin"
   cat > "$TEST_DIR/bin/claude" << 'EOF'
 #!/bin/sh
+read -r _discard 2>/dev/null || true
 printf 'PASS\n## Phase 1: Hello\nDo something\n'
 printf '{"type":"tool_use","name":"Edit","input":{}}\n'
 exit 0

--- a/tests/test_wizard_features.sh
+++ b/tests/test_wizard_features.sh
@@ -34,6 +34,7 @@ PLAN
   mkdir -p "$TEST_DIR/bin"
   cat > "$TEST_DIR/bin/claude" << 'EOF'
 #!/bin/sh
+read -r _discard 2>/dev/null || true
 printf 'PASS\n## Phase 1: Hello\nDo something\n'
 printf '{"type":"tool_use","name":"Edit","input":{}}\n'
 exit 0

--- a/tests/test_wizard_flags.sh
+++ b/tests/test_wizard_flags.sh
@@ -34,6 +34,7 @@ PLAN
   mkdir -p "$TEST_DIR/bin"
   cat > "$TEST_DIR/bin/claude" << 'EOF'
 #!/bin/sh
+read -r _discard 2>/dev/null || true
 printf 'PASS\n## Phase 1: Hello\nDo something\n'
 printf '{"type":"tool_use","name":"Edit","input":{}}\n'
 exit 0


### PR DESCRIPTION
## Summary

- Replace unidirectional `--print` pipeline with bidirectional `--permission-prompt-tool stdio` protocol using named pipes (FIFOs)
- Bypasses Claude Code's `.claude/` protected directory bug (v2.1.78+) where `--dangerously-skip-permissions` fails
- Add comprehensive API error classification covering all Anthropic API error types (529, 500/502/503, 408, 403, 404)

## Permission handling

New `lib/permission_handler.sh` with `permission_filter()` pipeline stage that intercepts `control_request` events from Claude Code's bidirectional protocol:

- **Auto-approve mode** (`--dangerously-skip-permissions`): Builds allow response with node.js one-liner, echoing original input as `updatedInput`
- **Interactive mode** (default): Prompts user via `/dev/tty` for y/n approval
- Handles `keep_alive` and `control_cancel_request` events

### Spike test results

| Approach | `.claude/skills/` write | Result |
|----------|------------------------|--------|
| `--dangerously-skip-permissions` (old) | BLOCKED | "you haven't granted it yet" |
| `--permission-prompt-tool stdio` (new) | **SUCCESS** | File written correctly |

## API error classification

| Error | HTTP | Retry strategy |
|-------|------|----------------|
| Overloaded | 529 | Exponential 5→120s, don't consume budget |
| Server error | 500/502/503 | Exponential 5→300s, don't consume budget |
| Timeout | 408 | Same as server errors |
| Rate limit | 429 | Wait 900s (existing) |
| Auth/Permission/NotFound | 401/403/404 | Fatal, don't retry |

## Test plan

- [x] `bats tests/test_permission_handler.sh` — 15/15 pass
- [x] `bats tests/test_retry.sh` — 166/166 pass
- [x] `bats tests/test_verify.sh` — 30/30 pass
- [x] `bats tests/test_integration_basic.sh` — 37/37 pass
- [x] `bats tests/test_integration_state2.sh` — 14/14 pass
- [x] `bats tests/test_integration_retry.sh` — 13/16 pass (3 pre-existing hangs)
- [x] `./tests/smoke.sh` — 8/8 pass
- [ ] End-to-end test with real Claude writing to `.claude/skills/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)