### PR TITLE
fix: make fake_claude self-healing when orphaned

### DIFF
--- a/tests/fake_claude
+++ b/tests/fake_claude
@@ -20,7 +20,42 @@
 # AI-parse prompts (containing "plan extraction assistant") emit phase headers.
 # Verification prompts (containing "verif") emit VERIFICATION_PASSED.
 
-FAKE_CLAUDE_DIR="${FAKE_CLAUDE_DIR:?FAKE_CLAUDE_DIR must be set}"
+# Self-healing: pass through to real claude if orphaned (FAKE_CLAUDE_DIR unset)
+if [ -z "$FAKE_CLAUDE_DIR" ]; then
+  case "$0" in
+    /*) _self="$0" ;;
+    */*) _self="$(cd "$(dirname "$0")" && pwd)/$(basename "$0")" ;;
+    *) _self=""
+       _oldifs2="${IFS-_UNSET_}"; IFS=:
+       for _d in $PATH; do
+         [ -x "$_d/$0" ] && { _self="$_d/$0"; break; }
+       done
+       if [ "$_oldifs2" = "_UNSET_" ]; then unset IFS; else IFS="$_oldifs2"; fi ;;
+  esac
+
+  if [ -z "$_self" ]; then
+    echo "fake_claude: orphaned and cannot resolve own path" >&2
+    exit 1
+  fi
+
+  _real=""
+  _oldifs="${IFS-_UNSET_}"; IFS=:
+  for _dir in $PATH; do
+    [ -z "$_dir" ] && continue
+    _candidate="$_dir/claude"
+    if [ -x "$_candidate" ] && ! [ "$_candidate" -ef "$_self" ]; then
+      _real="$_candidate"
+      break
+    fi
+  done
+  if [ "$_oldifs" = "_UNSET_" ]; then unset IFS; else IFS="$_oldifs"; fi
+
+  if [ -n "$_real" ]; then
+    exec "$_real" "$@"
+  fi
+  echo "fake_claude: orphaned (FAKE_CLAUDE_DIR unset) and no real claude found in PATH" >&2
+  exit 1
+fi
 FAKE_PROVIDER_DIR="$FAKE_CLAUDE_DIR"
 
 # Source shared utilities

--- a/tests/test_fake_claude.sh
+++ b/tests/test_fake_claude.sh
@@ -10,6 +10,9 @@ setup() {
   FAKE_DIR="$BATS_TEST_TMPDIR/fake"
   mkdir -p "$FAKE_DIR"
   export FAKE_CLAUDE_DIR="$FAKE_DIR"
+  # Source provider.sh (defines provider_write_tool_pattern used by has_write_actions)
+  SCRIPT_DIR="${BATS_TEST_DIRNAME}/.."
+  . "${BATS_TEST_DIRNAME}/../lib/provider.sh"
   # Source retry.sh for detection helpers
   . "${BATS_TEST_DIRNAME}/../lib/retry.sh"
   # Isolate CWD so fake_claude file writes don't pollute project directory
@@ -324,4 +327,29 @@ run_with_prompt() {
 @test "failure scenario: does NOT write files" {
   run_scenario "failure" > /dev/null 2>&1 || true
   [ ! -f "test.sh" ]
+}
+
+# --- Orphan handling (FAKE_CLAUDE_DIR unset) ---
+
+@test "orphaned: passes through to real claude in PATH" {
+  mkdir -p "$BATS_TEST_TMPDIR/real_bin"
+  printf '#!/bin/sh\necho REAL_CLAUDE_MARKER\n' > "$BATS_TEST_TMPDIR/real_bin/claude"
+  chmod +x "$BATS_TEST_TMPDIR/real_bin/claude"
+
+  unset FAKE_CLAUDE_DIR
+  output=$(PATH="$BATS_TEST_TMPDIR/real_bin" "$FAKE_CLAUDE" 2>&1)
+  [[ "$output" == *"REAL_CLAUDE_MARKER"* ]]
+}
+
+@test "orphaned: fails with clear error when no real claude in PATH" {
+  unset FAKE_CLAUDE_DIR
+  rc=0
+  output=$(PATH="/nonexistent" "$FAKE_CLAUDE" 2>&1) || rc=$?
+  [ "$rc" -eq 1 ]
+  [[ "$output" == *"orphaned"* ]]
+}
+
+@test "orphaned: FAKE_CLAUDE_DIR set still works normally" {
+  output=$(echo "test" | "$FAKE_CLAUDE" --print 2>&1)
+  [[ "$output" == *'"type"'* ]]
 }


### PR DESCRIPTION
## Summary
- When `FAKE_CLAUDE_DIR` is unset (orphaned install), pass through to real `claude` instead of hard-failing
- Use POSIX-compatible self-detection (`-ef` for symlink safety) to avoid exec loops
- Fix pre-existing test failure: `has_write_actions` tests missing `provider.sh` source in setup

## Test plan
- [ ] `bats tests/test_fake_claude.sh` — 41/41 pass (3 new orphan tests)
- [ ] `./tests/smoke.sh` — 8/8 pass
- [ ] Manual: `FAKE_CLAUDE_DIR` unset + real claude in PATH → passthrough
- [ ] Manual: `FAKE_CLAUDE_DIR` unset + no claude → exit 1 + "orphaned" message