### PR TITLE
fix: add (skipped) option to LESSONS_SUMMARY

### DIFF
--- a/README.md
+++ b/README.md
@@ -529,6 +529,14 @@ LESSONS_SUMMARY: "Learned that caching improves performance by 50%"
 
 ClaudeLoop extracts this marker from the phase log and records it in lessons.md. This gives the self-improvement Claude richer context about decisions and pitfalls, not just timing metrics.
 
+**Skipping:** Write `(skipped)` when the phase produced no novel insight worth recording:
+
+```
+LESSONS_SUMMARY: (skipped)
+```
+
+Skip criteria: (1) clean verification with no discoveries, (2) would duplicate an existing CLAUDE.md rule, (3) insight too narrow to help future work. ClaudeLoop treats `(skipped)` as an intentional no-lesson and writes no summary line.
+
 **Note:** The summary text cannot contain quote characters (`"` or `'`). The extraction regex uses a simple delimiter match.
 
 The lessons file is included when runs are archived (`--archive`). Oxveil reads this file after session completion to offer self-improvement suggestions.

--- a/lib/lessons.sh
+++ b/lib/lessons.sh
@@ -41,6 +41,10 @@ extract_lessons_summary() {
     \'*\') _summary="${_summary#\'}"; _summary="${_summary%\'}" ;;
   esac
 
+  case "$(printf '%s' "$_summary" | tr '[:upper:]' '[:lower:]')" in
+    "(skipped)") return 0 ;;
+  esac
+
   printf '%s\n' "$_summary"
 }
 

--- a/lib/prompt.sh
+++ b/lib/prompt.sh
@@ -21,7 +21,9 @@ build_phase_prompt() {
 
 ## Lessons Summary
 When you complete this phase, end your final response with:
-LESSONS_SUMMARY: "<one sentence that helps future work on THIS codebase: a pattern, gotcha, architectural decision, or workflow insight specific to this project>"'
+LESSONS_SUMMARY: "<lesson>" OR "(skipped)" if this phase produced no novel, actionable insight
+
+Skip if: (1) clean verification with no discoveries, (2) duplicates CLAUDE.md rules, (3) insight too narrow to help future work.'
 
   if grep -qF '{{' "$template_file"; then
     # Substitution mode.
@@ -104,7 +106,9 @@ Implement the above phase completely. Make sure to:
 
 ## Lessons Summary
 When you complete this phase, end your final response with:
-LESSONS_SUMMARY: \"<one sentence that helps future work on THIS codebase: a pattern, gotcha, architectural decision, or workflow insight specific to this project>\""
+LESSONS_SUMMARY: \"<lesson>\" OR \"(skipped)\" if this phase produced no novel, actionable insight
+
+Skip if: (1) clean verification with no discoveries, (2) duplicates CLAUDE.md rules, (3) insight too narrow to help future work."
 }
 
 # Apply retry strategy: archive log, build retry context, optionally replace prompt

--- a/tests/test_lessons.sh
+++ b/tests/test_lessons.sh
@@ -344,6 +344,33 @@ EOF
   [ "$status" -eq 0 ]
 }
 
+@test "extract_lessons_summary: returns empty for (skipped)" {
+  mkdir -p .claudeloop/logs
+  echo 'LESSONS_SUMMARY: (skipped)' > .claudeloop/logs/phase-1.log
+
+  result=$(extract_lessons_summary ".claudeloop/logs/phase-1.log")
+
+  [ -z "$result" ]
+}
+
+@test "extract_lessons_summary: returns empty for quoted (skipped)" {
+  mkdir -p .claudeloop/logs
+  echo 'LESSONS_SUMMARY: "(skipped)"' > .claudeloop/logs/phase-1.log
+
+  result=$(extract_lessons_summary ".claudeloop/logs/phase-1.log")
+
+  [ -z "$result" ]
+}
+
+@test "extract_lessons_summary: returns empty for (SKIPPED) uppercase" {
+  mkdir -p .claudeloop/logs
+  echo 'LESSONS_SUMMARY: (SKIPPED)' > .claudeloop/logs/phase-1.log
+
+  result=$(extract_lessons_summary ".claudeloop/logs/phase-1.log")
+
+  [ -z "$result" ]
+}
+
 # =============================================================================
 # lessons_write_phase - validation integration
 # =============================================================================


### PR DESCRIPTION
## Summary
- Adds `(skipped)` escape hatch to LESSONS_SUMMARY prompt so phases with no novel insight produce no summary line
- `extract_lessons_summary()` returns empty for any capitalization of `(skipped)` (case-insensitive via `tr`)
- Prompt updated in both template and default code paths with explicit skip criteria

## Test plan
- [ ] `bats tests/test_lessons.sh` — 35 tests pass (3 new: lowercase, quoted, uppercase `(skipped)`)
- [ ] `./tests/smoke.sh` — 8/8 pass
- [ ] Direct library verification: `(skipped)`, `(SKIPPED)`, `"(skipped)"` all return empty; real lessons unaffected